### PR TITLE
Slack request url verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore environment variables
+.env

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.1'
 
+gem 'dotenv-rails', groups: [:development, :test]
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'
 # Use postgresql as the database for Active Record
@@ -40,6 +42,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.7'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-rails'
 end
 
 group :development do
@@ -49,7 +52,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'pry-rails'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,10 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     diff-lcs (1.3)
+    dotenv (2.5.0)
+    dotenv-rails (2.5.0)
+      dotenv (= 2.5.0)
+      railties (>= 3.2, < 6.0)
     erubi (1.7.1)
     execjs (2.7.0)
     ffi (1.9.23)
@@ -195,6 +199,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   coffee-rails (~> 4.2)
+  dotenv-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,13 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## Local Testing Instructions To test a local development instance of
+QueueBuilder with Slack's API, your local development environment will need to
+be exposed to the open internet.  One way to achieve this is to use the
+[ngrok](https://ngropk.com).  This service can be used to create a http or
+https tunnel to your local development environment.  After installing ngrok,
+the tunnel can be created by running `ngrok http 3000`, where`3000` is the port
+for your local development service.  ngrok will provide a forwarding URL to be
+added to the Request URL field in the Slack interface for Event Subscriptions.
+The URL should have the path `/slack/event`.
 
-Things you may want to cover:
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -1,0 +1,25 @@
+class SlackController < ApplicationController
+  SlackEvents = {
+    url_verification: :url_verification
+  }
+
+  def event
+    render json: {none: :none}, status: 400
+  end
+
+  private
+  def handshake_approved?
+    return false if params[:token] != ENV["SLACK_TOKEN"]
+    return false unless !event_type_supported?
+
+    return true
+  end
+
+  def event_type_supported?
+    return false if type = params[:type]
+    SlackEvents.has_key?(type)
+  end
+
+  def signature_valid?
+  end
+end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -1,13 +1,21 @@
 class SlackController < ApplicationController
   SlackEvents = {
-    url_verification: :url_verification
+    "url_verification": SlackUrlVerification
   }
 
   def event
-    render json: {none: :none}, status: 400
+    if handshake_approved?
+      klass = SlackEvents[params[:type].to_sym]
+      result = klass.new(params).execute
+
+      return render json: result.json, status: result.status
+    end
+
+    render json: {}, status: :bad_request
   end
 
   private
+  # TODO: Move this to a service object.
   def handshake_approved?
     return false if params[:token] != ENV["SLACK_TOKEN"]
     return false unless !event_type_supported?
@@ -15,11 +23,9 @@ class SlackController < ApplicationController
     return true
   end
 
+  # TODO: Move this to a service object.
   def event_type_supported?
     return false if type = params[:type]
     SlackEvents.has_key?(type)
-  end
-
-  def signature_valid?
   end
 end

--- a/app/service_objects/event_response.rb
+++ b/app/service_objects/event_response.rb
@@ -1,0 +1,30 @@
+class EventResponse
+  attr_reader :body, :content_type, :status
+
+  def initialize(
+    body: {},
+    content_type: "application/json",
+    status: :bad_request,
+    error: ArgumentError
+  )
+    check_for_valid_status_code(status, error)
+
+    @body = body
+    @content_type = content_type
+    @status = status
+  end
+
+  private
+
+  def check_for_valid_status_code(status, error)
+    status_codes = Rack::Utils::SYMBOL_TO_STATUS_CODE
+
+    message = "EventResponse.status to be contained " +
+      "in Rack::Utils::HTTP_STATUS_CODES"
+
+    # raise error.new(message) unless status_codes.has_key?(status)
+    if !status_codes.has_key?(status)
+      raise error.new(message)
+    end
+  end
+end

--- a/app/slack_events/slack_url_verification.rb
+++ b/app/slack_events/slack_url_verification.rb
@@ -1,0 +1,41 @@
+class SlackUrlVerification
+  attr_reader :params
+
+  TYPE = 'url_verification'.freeze
+
+  def initialize(params, event_response = EventResponse, error = ArgumentError)
+    @params = params
+    @event_response = event_response
+
+    raise error.new("missing slack event type") unless params.has_key?(:type)
+    raise error.new("missing slack event token") unless params.has_key?(:token)
+    raise error.new("missing slack event challenge") \
+      unless params.has_key?(:challenge)
+    raise error.new("invalid slack event type") if params[:type] != TYPE
+  end
+
+  def execute
+    content_type = "application/json"
+
+    if params[:token] == ENV["SLACK_TOKEN"]
+      body = {"challenge": params[:challenge]}.to_json
+      EventResponse.new(
+        status: :ok,
+        content_type: content_type,
+        body: body
+      )
+    else
+      EventResponse.new(
+        status: :bad_request,
+        content_type: content_type,
+        body: {}.to_json
+      )
+    end
+  end
+
+  def unexecute
+    raise NotImplementedError.new(
+      "SlackUrlVerification does not implement unexecute"
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,3 @@
 Rails.application.routes.draw do
   get 'slack/event'
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  get 'slack/event'
+  post 'slack/event'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  get 'slack/event'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/slack_controller_spec.rb
+++ b/spec/controllers/slack_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SlackController, type: :controller do
+
+  describe "POST #event" do
+    describe "URL verification handshake" do
+      describe "with a valid request" do
+        it "returns the challenge string" do
+          ENV["TEST_TOKEN"] = "test_token"
+
+          params = {
+            "token": ENV["TEST_TOKEN"],
+            "challenge": "test_challenge",
+            "type": "url_verification"
+          }
+
+          post :event, { params: params }
+
+          expect(response).to have_http_status(:success)
+          expect(response.content_type).to eq "application/json"
+        end
+      end
+    end
+  end
+
+end

--- a/spec/controllers/slack_controller_spec.rb
+++ b/spec/controllers/slack_controller_spec.rb
@@ -1,26 +1,83 @@
 require 'rails_helper'
 
 RSpec.describe SlackController, type: :controller do
-
   describe "POST #event" do
     describe "URL verification handshake" do
       describe "with a valid request" do
-        it "returns the challenge string" do
-          ENV["TEST_TOKEN"] = "test_token"
+        before(:each) do
+          ENV["SLACK_TOKEN"] = "test_token"
 
-          params = {
-            "token": ENV["TEST_TOKEN"],
+          @params = {
+            "token": ENV["SLACK_TOKEN"],
             "challenge": "test_challenge",
             "type": "url_verification"
           }
+        end
 
-          post :event, { params: params }
+        it "creates a new Slack command class and calls execute" do
+          post :event, { params: @params }
+
+          expect(SlackUrlVerification).to have_received(:new)
+          expect(instance).to have_received(:execute)
+        end
+
+        it "renders the command instance response" do
+          post :event, { params: @params }
 
           expect(response).to have_http_status(:success)
           expect(response.content_type).to eq "application/json"
+          expect(response.body).to eq(@params[:challenge].to_json)
+        end
+      end
+
+      describe "with an invalid request" do
+        describe "with an invalid token" do
+          it "returns a 400 status" do
+            ENV["SLACK_TOKEN"] = "test_token"
+
+            params = {
+              "token": "invalid token",
+              "challenge": "test_challenge",
+              "type": "url_verification"
+            }
+
+            post :event, { params: params }
+
+            expect(response).to have_http_status(:bad_request)
+          end
+        end
+
+        describe "without a challenge param" do
+          it "returns a 400 status" do
+            ENV["SLACK_TOKEN"] = "test_token"
+
+            params = {
+              "token": ENV["SLACK_TOKEN"],
+              "type": "url_verification"
+            }
+
+            post :event, { params: params }
+
+            expect(response).to have_http_status(:bad_request)
+          end
+        end
+
+        describe "with an invalid type " do
+          it "returns a 400 status" do
+            ENV["SLACK_TOKEN"] = "test_token"
+
+            params = {
+              "token": ENV["SLACK_TOKEN"],
+              "challenge": "test_challenge",
+              "type": "invalid_type"
+            }
+
+            post :event, { params: params }
+
+            expect(response).to have_http_status(:bad_request)
+          end
         end
       end
     end
   end
-
 end

--- a/spec/service_object/event_response_spec.rb
+++ b/spec/service_object/event_response_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe EventResponse do
+  describe "#initialize" do
+    let(:response_data) {
+      {
+        body: "test body",
+        content_type: "content type",
+        status: :ok
+      }
+    }
+
+    describe "default values" do
+      it ".body defaults to an empty hash" do
+        expect(EventResponse.new.body).to eq({})
+      end
+
+      it ".content_type defaults to application/json" do
+        expect(EventResponse.new.content_type).to eq("application/json")
+      end
+
+      it ".status defaults to 400 :bad_request" do
+        expect(EventResponse.new.status).to eq(:bad_request)
+      end
+    end
+
+    describe "arguments override defaults" do
+      let(:event) { EventResponse.new(**response_data) }
+
+      it "sets body" do
+        expect(event.body).to eq(response_data[:body])
+      end
+
+      it "sets content_type" do
+        expect(event.content_type).to eq(response_data[:content_type])
+      end
+
+      it "sets status" do
+        expect(event.status).to eq(response_data[:status])
+      end
+    end
+
+    describe "status parameter" do
+      it "raises ArgumentError if not contained in HTTP status codes" do
+        invalid_status_code = { status: :invalid_status_code }
+
+        error_message = "EventResponse.status to be contained " +
+          "in Rack::Utils::HTTP_STATUS_CODES"
+
+        expect {
+          EventResponse.new(**invalid_status_code)
+        }.to raise_error(ArgumentError, error_message)
+      end
+    end
+  end
+end

--- a/spec/slack_events/slack_url_verification_spec.rb
+++ b/spec/slack_events/slack_url_verification_spec.rb
@@ -19,37 +19,6 @@ RSpec.describe SlackUrlVerification do
       expect(command.params).to eq(params)
     end
 
-    it "requires a 'url_verification' type" do
-      params[:type] = 'not_url_vertification'
-
-      expect {
-        SlackUrlVerification.new(params)
-      }.to raise_error(error, "invalid slack event type")
-    end
-
-    it "requires a type" do
-      params.delete(:type)
-
-      expect {
-        SlackUrlVerification.new(params)
-      }.to raise_error(error, "missing slack event type")
-    end
-
-    it "requires a token" do
-      params.delete(:token)
-
-      expect {
-        SlackUrlVerification.new(params)
-      }.to raise_error(error, "missing slack event token")
-    end
-
-    it "requires a challenge" do
-      params.delete(:challenge)
-
-      expect {
-        SlackUrlVerification.new(params)
-      }.to raise_error(error, "missing slack event challenge")
-    end
   end
 
   describe ".execute" do
@@ -81,7 +50,41 @@ RSpec.describe SlackUrlVerification do
       end
     end
 
-    describe "with invalid token" do
+    describe("with missing params keys") do
+      it "requires a 'url_verification' type" do
+        params[:type] = 'not_url_vertification'
+
+        expect(
+          SlackUrlVerification.new(params).execute.status
+        ).to be(:bad_request)
+      end
+
+      it "requires a type" do
+        params.delete(:type)
+
+        expect(
+          SlackUrlVerification.new(params).execute.status
+        ).to be(:bad_request)
+      end
+
+      it "requires a token" do
+        params.delete(:token)
+
+        expect(
+          SlackUrlVerification.new(params).execute.status
+        ).to be(:bad_request)
+      end
+
+      it "requires a challenge" do
+        params.delete(:challenge)
+
+        expect(
+          SlackUrlVerification.new(params).execute.status
+        ).to be(:bad_request)
+      end
+    end
+
+    describe "with a properly formed invalid token" do
       let(:invalid_token) {
         {
           token: "invalid_token",

--- a/spec/slack_events/slack_url_verification_spec.rb
+++ b/spec/slack_events/slack_url_verification_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.describe SlackUrlVerification do
+  ENV["SLACK_TOKEN"] = "test_token"
+
+  let(:params) {
+    {
+      token: ENV["SLACK_TOKEN"],
+      challenge: "test_challenge",
+      type: "url_verification"
+    }
+  }
+
+  describe "#initialize" do
+    let(:error) { ArgumentError }
+
+    it "sets a params attributes" do
+      command = SlackUrlVerification.new(params)
+      expect(command.params).to eq(params)
+    end
+
+    it "requires a 'url_verification' type" do
+      params[:type] = 'not_url_vertification'
+
+      expect {
+        SlackUrlVerification.new(params)
+      }.to raise_error(error, "invalid slack event type")
+    end
+
+    it "requires a type" do
+      params.delete(:type)
+
+      expect {
+        SlackUrlVerification.new(params)
+      }.to raise_error(error, "missing slack event type")
+    end
+
+    it "requires a token" do
+      params.delete(:token)
+
+      expect {
+        SlackUrlVerification.new(params)
+      }.to raise_error(error, "missing slack event token")
+    end
+
+    it "requires a challenge" do
+      params.delete(:challenge)
+
+      expect {
+        SlackUrlVerification.new(params)
+      }.to raise_error(error, "missing slack event challenge")
+    end
+  end
+
+  describe ".execute" do
+    describe "with a valid token" do
+      let(:slack_url_verification) {
+        SlackUrlVerification.new(params)
+      }
+
+      it "returns an EventResponse object" do
+        expect(slack_url_verification.execute).to be_a(EventResponse)
+      end
+
+      it "returns an EventResponse with 200 Ok status" do
+        status = slack_url_verification.execute.status
+
+        expect(status).to eq(:ok)
+      end
+
+      it "returns an EventResponse with application/json content type" do
+        content_type = slack_url_verification.execute.content_type
+
+        expect(content_type).to eq("application/json")
+      end
+
+      it "returns an EventResponse with the challenge key" do
+        body = slack_url_verification.execute.body
+
+        expect(body).to eq({"challenge": params[:challenge]}.to_json)
+      end
+    end
+
+    describe "with invalid token" do
+      let(:invalid_token) {
+        {
+          token: "invalid_token",
+          challenge: "test_challenge",
+          type: "url_verification"
+        }
+      }
+
+      it "returns an EventResponse with a 400 Bad Request status" do
+        status = SlackUrlVerification.new(invalid_token).execute.status
+
+        expect(status).to eq(:bad_request)
+      end
+
+      it "returns an EventResponse with application/json content type" do
+        content_type = SlackUrlVerification
+          .new(invalid_token)
+          .execute
+          .content_type
+
+        expect(content_type).to eq("application/json")
+      end
+
+      it "returns an EventResponse with a an empty JSON object body" do
+        body = SlackUrlVerification
+          .new(invalid_token)
+          .execute
+          .body
+
+        expect(body).to eq({}.to_json)
+      end
+    end
+  end
+
+  describe ".unexecute" do
+    it "raises a NotImplementedError" do
+      message = "SlackUrlVerification does not implement unexecute"
+
+      expect {
+        SlackUrlVerification.new(params).unexecute
+      }.to raise_error(NotImplementedError, message)
+    end
+  end
+end


### PR DESCRIPTION
Why:

- Slack requires apps to be able to complete a url verification handshake.

This change addresses the need by:

- Creating the SlackController to handle all incoming events from Slack.
- Creating an EvenResponse object to wrap events responses to be returned to Slack.
- Creating a SlackUrlVerification class to handle the url verification handshake.

